### PR TITLE
Adding Puzzle, Scheduler, and Processor Game from MIT and LLSC

### DIFF
--- a/Activities.md
+++ b/Activities.md
@@ -7,5 +7,5 @@ The repository currently contains the following activities:
 5. [BCCD](https://github.com/SIGHPC-Education-Chapter/BCCD)
 6. [Piction](https://github.com/SIGHPC-Education-Chapter/Piction)
 7. [The Puzzle Game](https://github.com/llsc-supercloud/hpc-games)
-8. [The Scheduler Game](https://github.com/llsc-supercloud/hpc-games)
-9. [The Processor Game](https://github.com/llsc-supercloud/hpc-games)
+8. [Be the Scheduler Game](https://github.com/llsc-supercloud/hpc-games)
+9. [Be the Processor Game](https://github.com/llsc-supercloud/hpc-games)

--- a/Activities.md
+++ b/Activities.md
@@ -6,3 +6,6 @@ The repository currently contains the following activities:
 4. [The supercompuing challange app](https://github.com/SIGHPC-Education-Chapter/SuperComputingChallenge)
 5. [BCCD](https://github.com/SIGHPC-Education-Chapter/BCCD)
 6. [Piction](https://github.com/SIGHPC-Education-Chapter/Piction)
+7. [The Puzzle Game](https://github.com/llsc-supercloud/hpc-games)
+8. [The Scheduler Game](https://github.com/llsc-supercloud/hpc-games)
+9. [The Processor Game](https://github.com/llsc-supercloud/hpc-games)


### PR DESCRIPTION
This PR adds a link to the [hpc-games](https://github.com/llsc-supercloud/hpc-games) repo to the `Activities.md` file for the Puzzle Game, Scheduler Game, and Processor Game.